### PR TITLE
Fix remaining Dependabot direct dev dependency alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
         "bootstrap": "4.5.0"
     },
     "devDependencies": {
-        "autoprefixer": "9.8.0",
+        "autoprefixer": "^10.4.21",
         "browser-sync": "2.26.7",
         "chokidar": "3.4.0",
         "concurrently": "5.2.0",
-        "postcss": "7.0.32",
+        "postcss": "^8.5.6",
         "prettier": "2.0.5",
-        "pug": "3.0.0",
+        "pug": "^3.0.3",
         "sass": "1.26.8",
-        "shelljs": "0.8.4"
+        "shelljs": "^0.10.0"
     }
 }


### PR DESCRIPTION
Updates the direct development dependencies that are still reported by Dependabot after removing the stale lockfile.

Changed only `package.json` devDependencies:
- `pug` -> `^3.0.3`
- `postcss` -> `^8.5.6`
- `autoprefixer` -> `^10.4.21` to match PostCSS 8
- `shelljs` -> `^0.10.0`

Notes:
- No website UI/UX source files were changed.
- This targets the remaining alerts detected directly in `package.json`.
- After merge, Dependabot should re-check the dependency manifest.